### PR TITLE
Bug fix: Array instead of concatonated string

### DIFF
--- a/lxc-backup.sh
+++ b/lxc-backup.sh
@@ -11,7 +11,7 @@ BACKUP_PREFIX=$(date +%Y%m%dt%H%M%S)
 
 LXC_PATH=$(lxc-config lxc.lxcpath)
 LXC_CONTAINERS=$(lxc-ls)
-LXC_CONTAINERS_ACTIVE=$(lxc-ls --active)
+LXC_CONTAINERS_ACTIVE=($(lxc-ls --active))
 
 
 # EXECUTION


### PR DESCRIPTION
${LXC_CONTAINERS_ACTIVE} was filled with a concatenated string (instead of array values).