### PR TITLE
Array instead of concatenated string 2

### DIFF
--- a/lxc-backup.sh
+++ b/lxc-backup.sh
@@ -10,7 +10,7 @@ BACKUP_PREFIX=$(date +%Y%m%dt%H%M%S)
 # INITIALISATION
 
 LXC_PATH=$(lxc-config lxc.lxcpath)
-LXC_CONTAINERS=$(lxc-ls)
+LXC_CONTAINERS=($(lxc-ls))
 LXC_CONTAINERS_ACTIVE=($(lxc-ls --active))
 
 


### PR DESCRIPTION
${LXC_CONTAINERS} was filled with a concatenated string stead of separated array values (similar as my previous pull request but for another variable).